### PR TITLE
Treat QUOTE as a block quote

### DIFF
--- a/bluebell/akn.peg
+++ b/bluebell/akn.peg
@@ -197,7 +197,7 @@ grammar akn
 
   nested_block_element <- indent content:block_element+ dedent <NestedBlockElement>
 
-  block_elements    <- block_list / table / longtitle / footnote / embedded_structure / line
+  block_elements    <- block_list / table / longtitle / footnote / block_quote / line
 
   block_list        <- block_item+ <BlockList>
 
@@ -265,11 +265,11 @@ grammar akn
   # Subflows (that go from inlines into nested complex structures)
   # ------------------------------------------------------------------------------
 
-  embedded_structure <- 'QUOTE' attrs:block_attrs? eol
+  block_quote       <- 'QUOTE' attrs:block_attrs? eol
                         indent
                           content:hier_block_element+
                         dedent
-                        <EmbeddedStructure>
+                        <BlockQuote>
 
   footnote          <- 'FOOTNOTE' space marker:([^ \n]+) space? eol
                        indent

--- a/bluebell/akn.py
+++ b/bluebell/akn.py
@@ -3719,7 +3719,7 @@ class Grammar(object):
                     address0 = self._read_footnote()
                     if address0 is FAILURE:
                         self._offset = index1
-                        address0 = self._read_embedded_structure()
+                        address0 = self._read_block_quote()
                         if address0 is FAILURE:
                             self._offset = index1
                             address0 = self._read_line()
@@ -4746,9 +4746,9 @@ class Grammar(object):
         self._cache['attr_value'][index0] = (address0, self._offset)
         return address0
 
-    def _read_embedded_structure(self):
+    def _read_block_quote(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['embedded_structure'].get(index0)
+        cached = self._cache['block_quote'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
@@ -4828,8 +4828,8 @@ class Grammar(object):
             self._offset = self._offset
         if address0 is not FAILURE:
             cls0 = type(address0)
-            address0.__class__ = type(cls0.__name__ + 'EmbeddedStructure', (cls0, self._types.EmbeddedStructure), {})
-        self._cache['embedded_structure'][index0] = (address0, self._offset)
+            address0.__class__ = type(cls0.__name__ + 'BlockQuote', (cls0, self._types.BlockQuote), {})
+        self._cache['block_quote'][index0] = (address0, self._offset)
         return address0
 
     def _read_footnote(self):

--- a/bluebell/akn_text.xsl
+++ b/bluebell/akn_text.xsl
@@ -246,8 +246,8 @@
     <xsl:text>&#10;&#10;</xsl:text>
   </xsl:template>
 
-  <!-- we only support embeddedStructure as a block quote, as the immediate child of a p tag -->
-  <xsl:template match="a:p/a:embeddedStructure">
+  <!-- block quotes as embeddedStructure -->
+  <xsl:template match="a:embeddedStructure">
     <xsl:param name="indent">0</xsl:param>
 
     <xsl:call-template name="indent">
@@ -401,9 +401,8 @@
        Content elements
        ............................................................................... -->
 
-  <!-- Ignore p tags that are just wrappers around embeddedStructure elements, because we only
-       support embeddedStructures wrapped in p tags, and they are handled elsewhere. -->
-  <xsl:template match="a:p[not(a:embeddedStructure)]">
+  <!-- p tags must end with a blank line -->
+  <xsl:template match="a:p">
     <xsl:param name="indent">0</xsl:param>
 
     <xsl:call-template name="indent">
@@ -414,7 +413,6 @@
       <xsl:with-param name="indent" select="$indent" />
     </xsl:apply-templates>
 
-    <!-- p tags must end with a blank line -->
     <xsl:text>&#10;&#10;</xsl:text>
 
     <xsl:apply-templates select=".//a:authorialNote" mode="content">

--- a/bluebell/types.py
+++ b/bluebell/types.py
@@ -359,7 +359,7 @@ class Line:
 # ------------------------------------------------------------------------------
 
 
-class EmbeddedStructure:
+class BlockQuote:
     def to_dict(self):
         info = {
             'type': 'element',
@@ -369,10 +369,11 @@ class EmbeddedStructure:
         if self.attrs.text:
             info['attribs'] = self.attrs.to_dict()
 
-        # embedded structure as block quote must be wrapped in a p (or other block) tag
+        # embeddedStructure is an inline element, so wrap it in a block
         return {
             'type': 'element',
-            'name': 'p',
+            'name': 'block',
+            'attribs': {'name': 'quote'},
             'children': [info],
         }
 

--- a/tests/test_subflows.py
+++ b/tests/test_subflows.py
@@ -18,10 +18,11 @@ QUOTE
     PART 1 - Heading
     
         part 1 text
-""", 'embedded_structure')
+""", 'block_quote')
         self.assertEqual({
             'type': 'element',
-            'name': 'p',
+            'name': 'block',
+            'attribs': {'name': 'quote'},
             'children': [{
                 'name': 'embeddedStructure',
                 'type': 'element',
@@ -92,7 +93,8 @@ something else
                 }]
             }, {
                 'type': 'element',
-                'name': 'p',
+                'name': 'block',
+                'attribs': {'name': 'quote'},
                 'children': [{
                     'name': 'embeddedStructure',
                     'type': 'element',
@@ -373,10 +375,11 @@ QUOTE
   QUOTE
   
     line two
-""", 'embedded_structure')
+""", 'block_quote')
         self.assertEqual({
             'type': 'element',
-            'name': 'p',
+            'name': 'block',
+            'attribs': {'name': 'quote'},
             'children': [{
                 'name': 'embeddedStructure',
                 'type': 'element',
@@ -389,7 +392,8 @@ QUOTE
                     }]
                 }, {
                     'type': 'element',
-                    'name': 'p',
+                    'name': 'block',
+                    'attribs': {'name': 'quote'},
                     'children': [{
                         'name': 'embeddedStructure',
                         'type': 'element',
@@ -411,10 +415,11 @@ QUOTE
 QUOTE{startQuote "}
 
   line one
-""", 'embedded_structure')
+""", 'block_quote')
         self.assertEqual({
             'type': 'element',
-            'name': 'p',
+            'name': 'block',
+            'attribs': {'name': 'quote'},
             'children': [{
                 'name': 'embeddedStructure',
                 'type': 'element',
@@ -432,9 +437,9 @@ QUOTE{startQuote "}
 
         xml = etree.tostring(self.generator.to_xml(tree), encoding='unicode', pretty_print=True)
 
-        self.assertEqual("""<p xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" eId="p_1">
-  <embeddedStructure startQuote="&quot;" eId="p_1__embeddedStructure_1">
-    <p eId="p_1__embeddedStructure_1__p_1">line one</p>
+        self.assertEqual("""<block xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" name="quote" eId="block_1">
+  <embeddedStructure startQuote="&quot;" eId="block_1__embeddedStructure_1">
+    <p eId="block_1__embeddedStructure_1__p_1">line one</p>
   </embeddedStructure>
-</p>
+</block>
 """, xml)


### PR DESCRIPTION
This swaps the semantics from “we support embedded structure but not inline” to “we support block quotes using embedded structure”. In future we can support inline embedded structures using a similar mechanism to how we do footnotes, which would then be different to this mechanism. Without <block>, we can't differentiate between the two.