### PR TITLE
Use hcontainer with mixed content to ensure validation

### DIFF
--- a/bluebell/xml.py
+++ b/bluebell/xml.py
@@ -221,7 +221,7 @@ class XmlGenerator:
             #   ...
             # hier
             #   ...
-            # container
+            # hcontainer
             #   ...
             # hier
             #   ...
@@ -251,8 +251,8 @@ class XmlGenerator:
                         kids.append(m.wrapUp(*make_group(eid + '__wrapup')))
                     else:
                         # more groups to come, use a container
-                        container_eid = self.ids.make(eid, {'name': 'container'})
-                        kids.append(m.container(*make_group(container_eid), name="container", eId=container_eid))
+                        hcontainer_eid = self.ids.make(eid, {'name': 'hcontainer'})
+                        kids.append(m.hcontainer(m.content(*make_group(hcontainer_eid)), name="hcontainer", eId=hcontainer_eid))
                 else:
                     # before hier
                     kids.append(m.intro(*make_group(eid + '__intro')))

--- a/tests/roundtrip/act.txt
+++ b/tests/roundtrip/act.txt
@@ -6,6 +6,8 @@ BODY
 
 CHAP 1 - Heading
 
+  intro
+
   SEC 1 - Section
 
     some **text** at //the start// with **multiple //types// of** markup
@@ -40,4 +42,12 @@ CHAP 1 - Heading
 
           TC
             cell 2
+
+  text in the middle
+
+  SEC 2
+
+    some text
+
+  wrap up
 

--- a/tests/test_hier.py
+++ b/tests/test_hier.py
@@ -170,9 +170,11 @@ PART
       <p eId="part_nn_1__sec_1__p_1">section 1 text</p>
     </content>
   </section>
-  <container name="container" eId="part_nn_1__container_1">
-    <p eId="part_nn_1__container_1__p_1">some interstitial text</p>
-  </container>
+  <hcontainer name="hcontainer" eId="part_nn_1__hcontainer_1">
+    <content>
+      <p eId="part_nn_1__hcontainer_1__p_1">some interstitial text</p>
+    </content>
+  </hcontainer>
   <section eId="part_nn_1__sec_2">
     <num>2</num>
     <content>


### PR DESCRIPTION
We were incorrectly using `container` when sandwiching content between hier elements inside another hier element.