### PR TITLE
In browsers, string values must come from select

### DIFF
--- a/bluebell/akn_text.xsl
+++ b/bluebell/akn_text.xsl
@@ -50,7 +50,7 @@
   <xsl:template name="escape-inlines">
     <xsl:param name="text" />
 
-    <!-- This works from the inside out, first escaping \ chars themselves, then escaping
+    <!-- This works from the inside out, first escaping backslash chars themselves, then escaping
          the different types of inline markers -->
     <xsl:call-template name="string-replace-all">
       <xsl:with-param name="text">
@@ -68,36 +68,37 @@
                               <xsl:with-param name="text">
                                 <xsl:call-template name="string-replace-all">
                                   <xsl:with-param name="text" select="$text" />
-                                  <xsl:with-param name="value">\</xsl:with-param>
-                                  <xsl:with-param name="replacement">\\</xsl:with-param>
+                                  <xsl:with-param name="value"><xsl:value-of select="'\'" /></xsl:with-param>
+                                  <xsl:with-param name="replacement"><xsl:value-of select="'\\'" /></xsl:with-param>
                                 </xsl:call-template>
                               </xsl:with-param>
-                              <xsl:with-param name="value">**</xsl:with-param>
-                              <xsl:with-param name="replacement">\**</xsl:with-param>
+                              <xsl:with-param name="value"><xsl:value-of select="'**'" /></xsl:with-param>
+                              <xsl:with-param name="replacement"><xsl:value-of select="'\**'" /></xsl:with-param>
                             </xsl:call-template>
                           </xsl:with-param>
-                          <xsl:with-param name="value">//</xsl:with-param>
-                          <xsl:with-param name="replacement">\//</xsl:with-param>
+                          <xsl:with-param name="value"><xsl:value-of select="'//'" /></xsl:with-param>
+                          <xsl:with-param name="replacement"><xsl:value-of select="'\//'" /></xsl:with-param>
                         </xsl:call-template>
                       </xsl:with-param>
-                      <xsl:with-param name="value">__</xsl:with-param>
-                      <xsl:with-param name="replacement">\__</xsl:with-param>
+                      <xsl:with-param name="value"><xsl:value-of select="'__'" /></xsl:with-param>
+                      <xsl:with-param name="replacement"><xsl:value-of select="'\__'" /></xsl:with-param>
                     </xsl:call-template>
                   </xsl:with-param>
-                  <xsl:with-param name="value">{{</xsl:with-param>
-                  <xsl:with-param name="replacement">\{{</xsl:with-param>
+                  <xsl:with-param name="value"><xsl:value-of select="'{{'" /></xsl:with-param>
+                  <xsl:with-param name="replacement"><xsl:value-of select="'\{{'" /></xsl:with-param>
                 </xsl:call-template>
               </xsl:with-param>
-              <xsl:with-param name="value">}}</xsl:with-param>
-              <xsl:with-param name="replacement">\}}</xsl:with-param>
+              <xsl:with-param name="value"><xsl:value-of select="'}}'" /></xsl:with-param>
+              <xsl:with-param name="replacement"><xsl:value-of select="'\}}'" /></xsl:with-param>
             </xsl:call-template>
           </xsl:with-param>
-          <xsl:with-param name="value">[[</xsl:with-param>
-          <xsl:with-param name="replacement">\[[</xsl:with-param>
+          <xsl:with-param name="value"><xsl:value-of select="'[['" /></xsl:with-param>
+          <xsl:with-param name="replacement"><xsl:value-of select="'\[['" /></xsl:with-param>
         </xsl:call-template>
       </xsl:with-param>
-      <xsl:with-param name="value">]]</xsl:with-param>
-      <xsl:with-param name="replacement">\]]</xsl:with-param>
+      <xsl:with-param name="value"><xsl:value-of select="']]'" /></xsl:with-param>
+      <xsl:with-param name="replacement"><xsl:value-of select="'\]]'" /></xsl:with-param>
+
     </xsl:call-template>
   </xsl:template>
 


### PR DESCRIPTION
When testing in chrome, turns out this is required.