### PR TITLE
Use special ascii chars for indent and dedent

### DIFF
--- a/bluebell/akn.peg
+++ b/bluebell/akn.peg
@@ -409,6 +409,7 @@ grammar akn
 
   newline           <- "\n"
 
-  indent            <- '{' eol
+  # These MUST match parser.INDENT and parser.DEDENT
+  indent            <- '\x0E' eol
 
-  dedent            <- '}' eol
+  dedent            <- '\x0F' eol

--- a/bluebell/akn.py
+++ b/bluebell/akn.py
@@ -7375,7 +7375,7 @@ class Grammar(object):
         chunk0, max0 = None, self._offset + 1
         if max0 <= self._input_size:
             chunk0 = self._input[self._offset:max0]
-        if chunk0 == '{':
+        if chunk0 == '':
             address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
@@ -7384,7 +7384,7 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append('\'{\'')
+                self._expected.append('\'\\x0E\'')
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
@@ -7416,7 +7416,7 @@ class Grammar(object):
         chunk0, max0 = None, self._offset + 1
         if max0 <= self._input_size:
             chunk0 = self._input[self._offset:max0]
-        if chunk0 == '}':
+        if chunk0 == '':
             address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
@@ -7425,7 +7425,7 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append('\'}\'')
+                self._expected.append('\'\\x0F\'')
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE

--- a/bluebell/parser.py
+++ b/bluebell/parser.py
@@ -61,8 +61,8 @@ class Parser(BaseParser):
 class AkomaNtosoParser:
     """ Parses plain text into well-formed Akoma Ntoso XML.
     """
-    indent = '{'
-    dedent = '}'
+    indent = INDENT
+    dedent = DEDENT
     indent_size = 2
 
     line_re = re.compile(r'^([ ]*)([^ \n])', re.M)

--- a/tests/support.py
+++ b/tests/support.py
@@ -16,8 +16,6 @@ class ParserSupport:
         super().setUp()
         self.frbr_uri = self.make_frbr_uri()
         self.parser = AkomaNtosoParser(self.frbr_uri)
-        self.parser.indent = '{'
-        self.parser.dedent = '}'
         self.generator = self.parser.generator
 
     def parse(self, text, root):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,6 +54,8 @@ class ParserTestCase(ParserSupport, TestCase):
         )
 
     def test_pre_parse_no_leading_whitespace(self):
+        self.parser.indent = '{'
+        self.parser.dedent = '}'
         self.assertEqual(
             "hello\n",
             self.parser.pre_parse("  hello"),
@@ -74,6 +76,8 @@ one
 """))
 
     def test_pre_parse_inconsistent_nesting(self):
+        self.parser.indent = '{'
+        self.parser.dedent = '}'
         self.parser.indent_size = 4
         self.assertEqual("""one
 {
@@ -94,6 +98,8 @@ one
 """))
 
     def test_pre_parse_tables(self):
+        self.parser.indent = '{'
+        self.parser.dedent = '}'
         self.assertEqual("""SECTION 1.
 
 {


### PR DESCRIPTION
This was the intent all along, it's a mistake that it wasn't added.
It may make debugging a bit harder, but it protects against having
{ and } in the raw input (which has happened at times).

An alternative is to use { and } but escape them when necessary.