### PR TITLE
crossHeading at mainBody level

### DIFF
--- a/tests/roundtrip/judgment-attachments.txt
+++ b/tests/roundtrip/judgment-attachments.txt
@@ -1,6 +1,14 @@
+BACKGROUND
+
+  
+
 ARGUMENTS
 
+  the above background is empty
+
   an argument
+
+  CROSSHEADING crossheading
 
 CONCLUSIONS
 
@@ -35,4 +43,18 @@ APPENDIX
 APPENDIX
 
   appendex 2 text
+
+APPENDIX
+
+  CROSSHEADING a lone crossheading
+
+APPENDIX
+
+  some text
+
+  CROSSHEADING crossheading
+
+  PART 2
+
+    a part
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -83,6 +83,9 @@ ANNEXURE a heading
 
   some text
   
+  CROSSHEADING crossheading
+CROSSHEADING crossheading2
+
 SCHEDULE heading
 
   schedule text
@@ -115,7 +118,26 @@ SCHEDULE heading
                             'type': 'text',
                             'value': 'some text',
                         }]
-                    }],
+                    }, {
+                        'name': 'hcontainer',
+                        'type': 'element',
+                        'attribs': {'name': 'hcontainer'},
+                         'children': [{
+                             'name': 'crossHeading',
+                             'type': 'element',
+                             'children': [{
+                                 'type': 'text',
+                                 'value': 'crossheading'
+                             }],
+                         }, {
+                             'name': 'crossHeading',
+                             'type': 'element',
+                             'children': [{
+                                 'type': 'text',
+                                 'value': 'crossheading2'
+                             }]
+                         }]
+                    }]
                 }]
             }, {
                 'type': 'element',
@@ -176,6 +198,10 @@ SCHEDULE heading
       </meta>
       <mainBody>
         <p eId="att_1__p_1">some text</p>
+        <hcontainer eId="att_1__hcontainer_1" name="hcontainer">
+          <crossHeading eId="att_1__hcontainer_1__crossHeading_1">crossheading</crossHeading>
+          <crossHeading eId="att_1__hcontainer_1__crossHeading_2">crossheading2</crossHeading>
+        </hcontainer>
       </mainBody>
     </doc>
   </attachment>


### PR DESCRIPTION
* crossHeading must be wrapped for `body`, `mainBody`, and `mainBody` equivalents such as `background` etc. (the latter are all of type `maincontent` in the AKN schema.