### PR TITLE
escape inlines better

### DIFF
--- a/tests/roundtrip/act-escapes.txt
+++ b/tests/roundtrip/act-escapes.txt
@@ -180,7 +180,7 @@ CHAP 4 - inline escapes
 
   outside \/\///italics//\/\/ outside
 
-  inside //\/\/italics\/\/// inside
+  inside //\/italics\/// inside
 
   inside //\/\/italics\/\/// inside
 

--- a/tests/roundtrip/act-escapes.txt
+++ b/tests/roundtrip/act-escapes.txt
@@ -166,3 +166,41 @@ CHAP 3 - Numbers
 
     multi
 
+CHAP 4 - inline escapes
+
+  outside \***bold**\* outside
+
+  outside \*\***bold**\*\* outside
+
+  inside **\*bold\*** inside
+
+  inside **\*\*bold\*\*** inside
+
+  outside \///italics//\/ outside
+
+  outside \/\///italics//\/\/ outside
+
+  inside //\/\/italics\/\/// inside
+
+  inside //\/\/italics\/\/// inside
+
+  outside \___underscore__\_ outside
+
+  outside \_\___underscore__\_\_ outside
+
+  inside __\_underscore\___ inside
+
+  inside __\_\_underscore\_\___ inside
+
+  \PART \***bold**
+
+  \PART \*\***bold**
+
+  \PART \///italics//
+
+  \PART \/\///italics//
+
+  \PART \___underscore__
+
+  \PART \_\___underscore__
+

--- a/tests/roundtrip/escapes.xml
+++ b/tests/roundtrip/escapes.xml
@@ -1,0 +1,69 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+  <act name="act">
+    <meta>
+      <identification source="#cobalt">
+        <FRBRWork>
+          <FRBRthis value="/akn/za/act/2009/10"/>
+          <FRBRuri value="/akn/za/act/2009/10"/>
+          <FRBRalias name="title" value="Untitled"/>
+          <FRBRdate date="2009" name="Generation"/>
+          <FRBRauthor href=""/>
+          <FRBRcountry value="za"/>
+          <FRBRnumber value="10"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="/akn/za/act/2009/10/eng"/>
+          <FRBRuri value="/akn/za/act/2009/10/eng"/>
+          <FRBRdate date="TODAY" name="Generation"/>
+          <FRBRauthor href=""/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="/akn/za/act/2009/10/eng"/>
+          <FRBRuri value="/akn/za/act/2009/10/eng"/>
+          <FRBRdate date="TODAY" name="Generation"/>
+          <FRBRauthor href=""/>
+        </FRBRManifestation>
+      </identification>
+      <references source="#cobalt">
+        <TLCOrganization eId="cobalt" href="https://github.com/laws-africa/cobalt" showAs="cobalt"/>
+      </references>
+    </meta>
+    <body>
+      <section eId="sec_1">
+        <num>1</num>
+        <content>
+          <p eId="sec_1__p_1">
+            <i>some/italics ending in a slash /</i>
+          </p>
+          <p eId="sec_1__p_2"><i>some/italics ending in a slash</i>/</p>
+          <p eId="sec_1__p_3">/<i>some/italics starting in a slash</i></p>
+          <p eId="sec_1__p_4">
+            <i>/some/italics starting in a slash</i>
+          </p>
+          <p eId="sec_1__p_5">/<i>some/italics on both sides</i>/</p>
+          <p eId="sec_1__p_6">
+            <i>/some/italics on both sides/</i>
+          </p>
+        </content>
+      </section>
+      <section eId="sec_2">
+        <num>2</num>
+        <content>
+          <p eId="sec_2__p_1">
+            <b>some*bold ending in a star *</b>
+          </p>
+          <p eId="sec_2__p_2"><b>some*bold ending in a star</b>*</p>
+          <p eId="sec_2__p_3">
+            <b>*some*bold starting in a star</b>
+          </p>
+          <p eId="sec_2__p_4">*<b>some*bold starting in a star</b></p>
+          <p eId="sec_2__p_5">*<b>some*bold on both sides</b>*</p>
+          <p eId="sec_2__p_6">
+            <b>*some*bold on both sides*</b>
+          </p>
+        </content>
+      </section>
+    </body>
+  </act>
+</akomaNtoso>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -187,3 +187,39 @@ SECTION 1.
   with white ** space** and bold
   and other}}
 '''.strip(), unparsed.strip())
+
+    def test_unparse_inline_escapes(self):
+        xml = '<section xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"><content><p><i>/italics/</i></p><p><b>*bold*</b></p><p><u>_underline_</u></p></content></section>'
+        unparsed = self.parser.unparse(xml)
+        self.assertEqual('''SEC
+
+  //\/italics\///
+
+  **\*bold\***
+
+  __\_underline\___
+'''.strip(), unparsed.strip())
+
+    def test_unparse_inline_escapes_outside(self):
+        xml = '<section xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"><content><p>/<i>italics</i>/</p><p>*<b>bold</b>*</p><p>_<u>underline</u>_</p></content></section>'
+        unparsed = self.parser.unparse(xml)
+        self.assertEqual('''SEC
+
+  \///italics//\/
+
+  \***bold**\*
+
+  \___underline__\_
+'''.strip(), unparsed.strip())
+
+    def test_unparse_inline_escapes_double(self):
+        xml = '<section xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"><content><p><i>//italics//</i></p><p><b>**bold**</b></p><p><u>__underline__</u></p></content></section>'
+        unparsed = self.parser.unparse(xml)
+        self.assertEqual('''SEC
+
+  //\/\/italics\/\///
+
+  **\*\*bold\*\***
+
+  __\_\_underline\_\___
+'''.strip(), unparsed.strip())

--- a/tests/test_round_trip.py
+++ b/tests/test_round_trip.py
@@ -59,6 +59,9 @@ class RoundTripTestCase(ParserSupport, TestCase):
     def test_attribs(self):
         self.roundtrip_xml('attribs', root='act')
 
+    def test_escapes(self):
+        self.roundtrip_xml('escapes', root='act')
+
     def test_act(self):
         self.roundtrip('act', 'act')
 


### PR DESCRIPTION
Fixes #108

escapes certain chars at the start and end of their matching inlines (bold, italics and underscore)