### PR TITLE
Include package data when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['docs', 'tests*']),
+    include_package_data=True,
 
     scripts=['bin/bluebell'],
 


### PR DESCRIPTION
Otherwise .xsl files are not included unless the package is installed in edit mode

ref: https://setuptools.pypa.io/en/latest/userguide/datafiles.html

Fixes https://lawsafrica.sentry.io/issues/4090656464/