### PR TITLE
prevent infinite recursion with xsltproc

### DIFF
--- a/bluebell/akn_text.xsl
+++ b/bluebell/akn_text.xsl
@@ -31,6 +31,7 @@
         <xsl:when test="contains($trim, substring($text, 1, 1))">
           <xsl:call-template name="string-ltrim">
             <xsl:with-param name="text" select="substring($text, 2)" />
+            <xsl:with-param name="trim" select="$trim" />
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>

--- a/bluebell/akn_text.xsl
+++ b/bluebell/akn_text.xsl
@@ -31,7 +31,6 @@
         <xsl:when test="contains($trim, substring($text, 1, 1))">
           <xsl:call-template name="string-ltrim">
             <xsl:with-param name="text" select="substring($text, 2)" />
-            <xsl:with-param name="trim" select="$trim" />
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
@@ -71,7 +70,7 @@
     <xsl:param name="text" />
     <xsl:param name="ch" select="substring($text, 1, 1)" />
 
-    <xsl:if test="substring($text, 1, 1) = $ch">
+    <xsl:if test="string-length($text) &gt; 0 and substring($text, 1, 1) = $ch">
       <xsl:value-of select="$ch" />
       <xsl:call-template name="prefix-run">
         <xsl:with-param name="text" select="substring($text, 2)" />
@@ -85,7 +84,7 @@
     <xsl:param name="text" />
     <xsl:param name="ch" select="substring($text, string-length($text))" />
 
-    <xsl:if test="substring($text, string-length($text)) = $ch">
+    <xsl:if test="string-length($text) &gt; 0 and substring($text, string-length($text)) = $ch">
       <xsl:value-of select="$ch" />
       <xsl:call-template name="suffix-run">
         <xsl:with-param name="text" select="substring($text, 1, string-length($text) - 1)" />


### PR DESCRIPTION
if a string is empty, then xsltproc seems to be happy comparing substring($string, 1, 1) to whitespace

for example, it will recurse infinitely when checking for the run of spaces at the start of an empty string, eg.

```
<part>
  <p>  <b>foo</b></p>
</p>
```

python's lxml and the browser don't seem to have this problem.